### PR TITLE
Update Twingate Recipes

### DIFF
--- a/Twingate/Twingate.download.recipe
+++ b/Twingate/Twingate.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/expanded/Distribution.pkg/Payload</string>
 				<key>purge_destination</key>
@@ -71,7 +71,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Twingate.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Twingate.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Twingate/Twingate.munki.recipe
+++ b/Twingate/Twingate.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Twingate and imports into Munki as a pkg.</string>
+	<string>Downloads the latest version of Twingate and imports into Munki as a pkg.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.ccaviness.munki.Twingate</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -26,8 +30,6 @@
 			<string>Twingate</string>
 			<key>display_name</key>
 			<string>Twingate</string>
-			<key>minimum_os_version</key>
-			<string>14</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -35,7 +37,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>2.3</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.ccaviness.download.Twingate</string>
 	<key>Process</key>
@@ -43,19 +45,29 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Twingate.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
-					<key>installs</key>
-					<array>
-						<dict>
-							<key>CFBundleShortVersionString</key>
-							<string>%version%</string>
-							<key>path</key>
-							<string>/Applications/Twingate.app</string>
-							<key>type</key>
-							<string>application</string>
-						</dict>
-					</array>
+					<key>version</key>
+					<string>%version%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>
@@ -73,6 +85,18 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/Applications</string>
+					<string>%RECIPE_CACHE_DIR%/expanded</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @ccaviness 

This PR adds in 

- `MunkiInstallsItemsCreator` with `derive_minimum_os_version` so that a full installs array is generated
- Changes `MunkiPkginfoMerger` to set the version so it that it no longer uses the pkg receipts of 0
- Adds `PathDeleter` to tidy up the unpacking steps after import

Output from a successful -v run
```
autopkg run -v Twingate.munki.recipe
Looking for com.github.ccaviness.download.Twingate...
Did not find com.github.ccaviness.download.Twingate in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.ccaviness.download.Twingate...
Found com.github.ccaviness.download.Twingate in recipe map
**load_recipe time: 0.005989124998450279
Processing Twingate.munki.recipe...
WARNING: Twingate.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 09 Sep 2024 14:02:50 GMT
URLDownloader: Storing new ETag header: "4650fd13f1d52f171b193135df632e48"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/downloads/Twingate.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Twingate.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-09-09 14:01:47 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Twingate Inc. (6GX8KVTR9H)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F0 A3 DF A5 5E 17 16 79 6E DA 60 8B 2A DA 9A 02 37 D1 5C 5F 7A 8B 
CodeSignatureVerifier:            02 62 BC EE 54 F4 31 B4 65 9B
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/downloads/Twingate.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/expanded
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/expanded/Distribution.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/Applications
Versioner
Versioner: Found version 2024.253 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/Applications/Twingate.app/Contents/Info.plist
FlatPkgPacker
FlatPkgPacker: Flattened /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/expanded/Distribution.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/Twingate-2024.253.pkg
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Twingate.app
MunkiInstallsItemsCreator: Derived minimum os version as: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.twingate.macos', 'CFBundleName': 'Twingate', 'CFBundleShortVersionString': '2024.253', 'CFBundleVersion': '17487', 'minosversion': '12.0', 'path': '/Applications/Twingate.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '12.0'} into pkginfo
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2024.253'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Twingate/Twingate-2024.253.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Twingate/Twingate-2024.253.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/Applications
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/expanded
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/receipts/Twingate.munki-receipt-20240919-103817.plist

The following new items were downloaded:
    Download Path                                                                                        
    -------------                                                                                        
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ccaviness.munki.Twingate/downloads/Twingate.pkg  

The following new items were imported into Munki:
    Name      Version   Catalogs  Pkginfo Path                           Pkg Repo Path                        Icon Repo Path  
    ----      -------   --------  ------------                           -------------                        --------------  
    Twingate  2024.253  testing   apps/Twingate/Twingate-2024.253.plist  apps/Twingate/Twingate-2024.253.pkg
```