### PR TITLE
Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
 -   repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.16.2
+    rev: v1.18.0
     hooks:
-    -   id: check-plists
-    -   id: check-autopkg-recipe-list
     -   id: check-autopkg-recipes
         args: ['--recipe-prefix=com.github.ccaviness.', '--strict']
+    -   id: forbid-autopkg-overrides
+    -   id: forbid-autopkg-trust-info


### PR DESCRIPTION
This PR updates the versions of hooks used by the pre-commit checks. It also makes these changes to the hooks used:

- Removes `check-plists`: this is redundant with `check-autopkg-recipes` since there are no non-recipe plists in this repo.
- Removes `check-autopkg-recipe-list` since there is no recipe list in this repo.
- Adds `forbid-autopkg-overrides` and `forbid-autopkg-trust-info` to prevent accidentally committing overrides into this repo.

```
% pre-commit run --all-files 
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
```