### PR TITLE
Use APLooseVersion in distutils fallback

### DIFF
--- a/Druva/DruvaExtractor.py
+++ b/Druva/DruvaExtractor.py
@@ -17,7 +17,7 @@ import json
 try:
     from packaging.version import Version
 except ImportError:
-    from distutils.version import LooseVersion as Version
+    from autopkglib import APLooseVersion as Version
 from autopkglib import URLGetter, ProcessorError
 
 __all__ = ["DruvaExtractor"]


### PR DESCRIPTION
AutoPkg has provided `APLooseVersion` since version 2.0.1 as a drop-in replacement for `distutils.version.LooseVersion`.

`DruvaExtractor` prefers `packaging.version.Version` and only the `except ImportError` fallback changes, switching from `distutils` to `APLooseVersion`. This enables the processor to keep working with a future version of AutoPkg that includes a Python 3.12 or 3.13 runtime and drops `distutils`. No `MinimumVersion` change is needed, as the affected recipes already require AutoPkg 2.3.

This affects only the rarely-used fallback path (when `packaging` is unavailable) and matches it for the dotted numeric versions Druva emits.
